### PR TITLE
Removed a duplicate entry which was under 13Including other templates

### DIFF
--- a/app/cheatsheet.yml
+++ b/app/cheatsheet.yml
@@ -232,7 +232,6 @@ twiginclude:
         - [ "Syntax", "Meaning"]
         - [ "`{% include '_header.twig' %}`", "Includes the file `_header.twig`."]
         - [ "`{% set v = {'title': 'Hello!'} %}`<br>`{% include '_header.twig' with v %}`", "You can set variables to contain literals, arrays, hashes, etc."]
-        - [ "`{% set foo = 'Hello ' ~ name %}`<br>`{% set foo = foo|merge(bar) %}`", "Use set to append strings or merge arrays."]
     table_linear: true
     postfix: |
         An alternative to using 'include', is to set up your templates using Template


### PR DESCRIPTION
Good day,

I found a duplicate entry in section "13. Including other templates":

```
{% set foo = 'Hello ' ~ name %}
{% set foo = foo|merge(bar) %}
 Use set to append strings or merge arrays.
```

It was not supposed to be here since it's correct section is "12. Setting variables".

P.S: This is my first pull request so please overlook the mistake which I might have made?
